### PR TITLE
Add travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+language: node_js
+node_js:
+  - "9.3.0"
+
+addons:
+  chrome: stable
+
+script:
+  - npm run lint
+  - npm run test-ci

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Ionic: How To
+[![Build Status](https://travis-ci.org/brunolm/ionic-how-to.svg?branch=master)](https://travis-ci.org/brunolm/ionic-how-to)
 
 Each Pull Request will contain explanation and steps taken to complete a feature.
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,4 @@ Each Pull Request will contain explanation and steps taken to complete a feature
 ## Tests
 
 - [Configure application tests](https://github.com/brunolm/ionic-how-to/pull/3)
+- [Add project on Travis CI](https://github.com/brunolm/ionic-how-to/pull/4)

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "ionic serve -c",
     "test": "karma start ./spec/karma.conf.js",
+    "test-ci": "karma start ./spec/karma.conf.js --single-run --headless",
     "device:android": "ionic cordova run android --device --livereload",
     "device:ios": "ionic cordova run ios --device --livereload",
     "ionic": "ionic",


### PR DESCRIPTION
- Enable project on Travis CI
- Add config file
```
sudo: required
language: node_js
node_js:
  - "9.3.0"

addons:
  chrome: stable

script:
  - npm run lint
  - npm run test-ci
```
- Add test-ci script (headless is a [custom param, see this line](https://github.com/brunolm/ionic-how-to/blob/d6e4c3f4441f2922a10f7830e91186ecd3c33db6/spec/karma.conf.js#L54))
```
"test-ci": "karma start ./spec/karma.conf.js --single-run --headless",
```

To add a tag badge on README go to Travis, click on the badge, select markdown

![badge](https://i.imgur.com/i1u7Z9t.png)