### PR TITLE
Add header in a shared module

### DIFF
--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -1,11 +1,4 @@
-<ion-header>
-  <ion-navbar>
-    <button ion-button menuToggle>
-      <ion-icon name="menu"></ion-icon>
-    </button>
-    <ion-title>Home</ion-title>
-  </ion-navbar>
-</ion-header>
+<ion-header app-header title="Home Header"></ion-header>
 
 <ion-content padding>
   <h3>Ionic Menu Starter</h3>

--- a/src/pages/home/home.module.ts
+++ b/src/pages/home/home.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
 
+import { SharedModule } from '../../shared/shared.module';
 import { HomePage } from './home';
 
 @NgModule({
   declarations: [HomePage],
   exports: [HomePage],
-  imports: [IonicPageModule.forChild(HomePage)],
+  imports: [IonicPageModule.forChild(HomePage), SharedModule],
 })
 export class HomePageModule {}

--- a/src/pages/list/list.html
+++ b/src/pages/list/list.html
@@ -1,11 +1,4 @@
-<ion-header>
-  <ion-navbar>
-    <button ion-button menuToggle>
-      <ion-icon name="menu"></ion-icon>
-    </button>
-    <ion-title>List</ion-title>
-  </ion-navbar>
-</ion-header>
+<ion-header app-header title="List Header"></ion-header>
 
 <ion-content>
   <ion-list>

--- a/src/pages/list/list.module.ts
+++ b/src/pages/list/list.module.ts
@@ -1,11 +1,12 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
 
+import { SharedModule } from '../../shared/shared.module';
 import { ListPage } from './list';
 
 @NgModule({
   declarations: [ListPage],
   exports: [ListPage],
-  imports: [IonicPageModule.forChild(ListPage)],
+  imports: [IonicPageModule.forChild(ListPage), SharedModule],
 })
 export class ListPageModule {}

--- a/src/shared/header.component.ts
+++ b/src/shared/header.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: '[app-header]',
+  templateUrl: 'header.html',
+})
+export class HeaderComponent {
+  @Input()
+  title: string;
+}

--- a/src/shared/header.html
+++ b/src/shared/header.html
@@ -1,0 +1,6 @@
+<ion-navbar>
+  <button ion-button menuToggle>
+    <ion-icon name="menu"></ion-icon>
+  </button>
+  <ion-title>{{ title }}</ion-title>
+</ion-navbar>

--- a/src/shared/header.scss
+++ b/src/shared/header.scss
@@ -1,0 +1,2 @@
+[app-header] {
+}

--- a/src/shared/shared.module.ts
+++ b/src/shared/shared.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { IonicModule } from 'ionic-angular';
+
+import { HeaderComponent } from './header.component';
+
+@NgModule({
+  declarations: [HeaderComponent],
+  exports: [HeaderComponent],
+  imports: [BrowserModule, IonicModule],
+})
+export class SharedModule {}


### PR DESCRIPTION
`<ion-header>` should be a child of a page. To use it in a shared component you can make the component selector be an attribute and use it in a `<ion-header>`.

```
  selector: '[app-header]',

  <ion-header app-header title="Home Header"></ion-header>
```

Correct:
```
<page-home>
  <ion-header app-header>
```